### PR TITLE
refactor: consolidate waveform and encoding validation

### DIFF
--- a/echopype/calibrate/api.py
+++ b/echopype/calibrate/api.py
@@ -3,11 +3,12 @@ import xarray as xr
 
 from ..core import SONAR_MODELS
 from ..echodata import EchoData
-from ..echodata.simrad import check_input_args_combination, retrieve_correct_beam_group
+from ..echodata.simrad import retrieve_correct_beam_group
 from ..utils.log import _init_logger
 from ..utils.prov import echopype_prov_attrs, source_files_vars
 from .calibrate_azfp import CalibrateAZFP
 from .calibrate_ek import CalibrateEK60, CalibrateEK80
+from .utils import check_input_args_combination
 
 CALIBRATOR = {
     "EK60": CalibrateEK60,

--- a/echopype/calibrate/utils.py
+++ b/echopype/calibrate/utils.py
@@ -1,0 +1,24 @@
+"""Utilities shared by calibration workflows."""
+
+
+def check_input_args_combination(
+    waveform_mode: str, encode_mode: str, pulse_compression: bool = None
+) -> None:
+    """Validate waveform, encoding, and pulse-compression options."""
+    if waveform_mode not in ["CW", "BB"]:
+        raise ValueError("The input waveform_mode must be either 'CW' or 'BB'!")
+
+    if encode_mode not in ["complex", "power"]:
+        raise ValueError("The input encode_mode must be either 'complex' or 'power'!")
+
+    if waveform_mode == "BB" and encode_mode == "power":
+        raise ValueError(
+            "Data from broadband ('BB') transmission must be recorded as complex samples"
+        )
+
+    if pulse_compression is not None:
+        if pulse_compression and ((waveform_mode != "BB") or (encode_mode != "complex")):
+            raise RuntimeError(
+                "Pulse compression can only be used with "
+                "waveform_mode='BB' and encode_mode='complex'"
+            )

--- a/echopype/echodata/simrad.py
+++ b/echopype/echodata/simrad.py
@@ -10,6 +10,8 @@ from ..calibrate.utils import check_input_args_combination
 from ..core import SONAR_MODELS
 from .echodata import EchoData
 
+__all__ = ["check_input_args_combination", "retrieve_correct_beam_group"]
+
 
 def _retrieve_correct_beam_group_EK60(
     echodata: EchoData, waveform_mode: str, encode_mode: str

--- a/echopype/echodata/simrad.py
+++ b/echopype/echodata/simrad.py
@@ -6,8 +6,8 @@ from typing import Optional, Tuple
 
 import numpy as np
 
-from ..core import SONAR_MODELS
 from ..calibrate.utils import check_input_args_combination
+from ..core import SONAR_MODELS
 from .echodata import EchoData
 
 

--- a/echopype/echodata/simrad.py
+++ b/echopype/echodata/simrad.py
@@ -7,46 +7,8 @@ from typing import Optional, Tuple
 import numpy as np
 
 from ..core import SONAR_MODELS
+from ..calibrate.utils import check_input_args_combination
 from .echodata import EchoData
-
-
-def check_input_args_combination(
-    waveform_mode: str, encode_mode: str, pulse_compression: bool = None
-) -> None:
-    """
-    Checks that the ``waveform_mode`` and ``encode_mode`` have
-    the correct values and that the combination of input arguments are valid, without
-    considering the actual data.
-
-    Parameters
-    ----------
-    waveform_mode: str
-        Type of transmit waveform
-    encode_mode: str
-        Type of encoded return echo data
-    pulse_compression: bool
-        States whether pulse compression should be used
-    """
-
-    if waveform_mode not in ["CW", "BB"]:
-        raise ValueError("The input waveform_mode must be either 'CW' or 'BB'!")
-
-    if encode_mode not in ["complex", "power"]:
-        raise ValueError("The input encode_mode must be either 'complex' or 'power'!")
-
-    # BB has complex data only, but CW can have complex or power data
-    if (waveform_mode == "BB") and (encode_mode == "power"):
-        raise ValueError(
-            "Data from broadband ('BB') transmission must be recorded as complex samples"
-        )
-
-    # make sure that we have BB and complex inputs, if pulse compression is selected
-    if pulse_compression is not None:
-        if pulse_compression and ((waveform_mode != "BB") or (encode_mode != "complex")):
-            raise RuntimeError(
-                "Pulse compression can only be used with "
-                "waveform_mode='BB' and encode_mode='complex'"
-            )
 
 
 def _retrieve_correct_beam_group_EK60(

--- a/echopype/tests/calibrate/test_utils.py
+++ b/echopype/tests/calibrate/test_utils.py
@@ -1,0 +1,25 @@
+import pytest
+
+from echopype.calibrate.utils import check_input_args_combination
+
+
+@pytest.mark.parametrize(
+    ("waveform_mode", "encode_mode"),
+    [("CW", "power"), ("CW", "complex"), ("BB", "complex")],
+)
+def test_check_input_args_combination_accepts_valid_modes(waveform_mode, encode_mode):
+    check_input_args_combination(waveform_mode, encode_mode)
+
+
+@pytest.mark.parametrize(
+    ("waveform_mode", "encode_mode"),
+    [("FM", "complex"), ("CW", "raw"), ("BB", "power")],
+)
+def test_check_input_args_combination_rejects_invalid_modes(waveform_mode, encode_mode):
+    with pytest.raises(ValueError):
+        check_input_args_combination(waveform_mode, encode_mode)
+
+
+def test_check_input_args_combination_rejects_invalid_pulse_compression():
+    with pytest.raises(RuntimeError, match="Pulse compression"):
+        check_input_args_combination("CW", "complex", pulse_compression=True)


### PR DESCRIPTION
## Summary

- move waveform and encoding combination validation into `calibrate.utils`
- reuse the helper from calibration and Simrad beam selection
- add unit coverage for valid and invalid combinations

Closes #1745

## Validation

- `python -m compileall -q echopype`
- `git diff --check`

The full test environment is not available in this Windows checkout.
