### PR TITLE
Resolve some doc build warnings [skip ci]

### DIFF
--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -10,16 +10,6 @@ API components that most users will interact with.
    `0.4.1 API page <https://echopype.readthedocs.io/en/v0.4.1/api.html>`_
    if you're using a previous release. That workflow is now removed.
 
-**Content**
-
-* `EchoData class`_
-* `Open raw and converted files`_
-* `Combine EchoData objects`_
-* `Data processing subpackages`_
-* `Utilities`_
-* `Visualization subpackage`_
-
-
 EchoData class
 --------------
 
@@ -73,7 +63,7 @@ commongrid
    :no-heading:
 
 consolidate
-^^^^^^^^^^
+^^^^^^^^^^^
 
 .. automodapi:: echopype.consolidate
    :no-inheritance-diagram:
@@ -108,9 +98,3 @@ Utilities
    :no-inheritance-diagram:
    :no-heading:
    :members: calc_absorption, calc_sound_speed
-
-Visualization subpackage
-------------------------
-
-.. automodule:: echopype.visualize
-   :members: create_echogram

--- a/echopype/echodata/combine.py
+++ b/echopype/echodata/combine.py
@@ -874,12 +874,14 @@ def combine_echodata(
         Specifies what channels should be selected for an ``EchoData`` group
         with a ``channel`` dimension (before combination).
 
-        - if a list is provided, then each ``EchoData`` group with a ``channel`` dimension
-        will only contain the channels in the provided list
-        - if a dictionary is provided, the dictionary should have keys specifying only beam
-        groups (e.g. "Sonar/Beam_group1") and values as a list of channel names to select
-        within that beam group. The rest of the ``EchoData`` groups with a ``channel`` dimension
-        will have their selected channels chosen automatically.
+        - if a list is provided, then each ``EchoData`` group with a
+          ``channel`` dimension will only contain the channels in the
+          provided list
+        - if a dictionary is provided, the dictionary should have keys
+          specifying only beam groups (e.g. "Sonar/Beam_group1") and
+          values as a list of channel names to select within that beam
+          group. The rest of the ``EchoData`` groups with a ``channel``
+          dimension will have their selected channels chosen automatically.
 
     Returns
     -------

--- a/echopype/qc/api.py
+++ b/echopype/qc/api.py
@@ -53,7 +53,7 @@ def coerce_increasing_time(
         the median pinging interval is used to infer the next ping time
 
     Examples
-    -----
+    --------
     >>> import xarray as xr
     >>> from echopype.qc.api import exist_reversed_time, coerce_increasing_time
     >>> ds = xr.open_dataset("my_dataset.nc")


### PR DESCRIPTION
When the docs are built there are some warnings. This PR resolves some of them:

- There is a section in the docs for the visualize functionality, but that code was removed from echopype a few versions ago
- Headings in api.rst and api.py didn't have the right number of underscore characters
- A docstring list in combine.py didn't render correctly because the list items weren't indented
- Removed an inline toc as it is already provided via the right-hand toc 

A note - these warnings can adversely affect the generated documentation but they aren't very visible during the CI runs. I only noticed them when running the build locally. There is the option to have the doc build fail on warnings, but currently there are some warnings that seem hard to prevent (they are more info than warning).