### PR TITLE
Fix chunk formatting warning and fix consolidated metadata not implemented warning

### DIFF
--- a/echopype/tests/echodata/test_echodata.py
+++ b/echopype/tests/echodata/test_echodata.py
@@ -854,12 +854,11 @@ def test_echodata_delete(caplog, ek60_path):
 
 
 @pytest.mark.unit
-def test_to_zarr_no_consolidated_metadata_warning():
+def test_to_zarr_no_consolidated_metadata_warning(test_path):
     with warnings.catch_warnings(record=True) as caught_warnings:
         warnings.simplefilter("always", ZarrUserWarning)
         ed = open_raw(
-            "echopype/test_data/ek60/ncei-wcsd/"
-            "Summer2017-D20170719-T211347.raw",
+            test_path["EK60"] / "ncei-wcsd/SH1701/TEST-D20170114-T202932.raw",
             sonar_model="EK60",
         )
         ed.to_zarr(overwrite=True)

--- a/echopype/tests/echodata/test_echodata.py
+++ b/echopype/tests/echodata/test_echodata.py
@@ -855,6 +855,12 @@ def test_echodata_delete(caplog, ek60_path):
 
 @pytest.mark.unit
 def test_to_zarr_no_consolidated_metadata_warning(test_path):
+    """
+    This test checks that we explicitly use `consolidated=False`, otherwise
+    xarray will attempt to write consolidated metadata but Zarr v3 does not
+    support this yet.
+    TODO remove this test once Zarr v3 supports consolidated metadata.
+    """
     with warnings.catch_warnings(record=True) as caught_warnings:
         warnings.simplefilter("always", ZarrUserWarning)
         ed = open_raw(
@@ -862,7 +868,6 @@ def test_to_zarr_no_consolidated_metadata_warning(test_path):
             sonar_model="EK60",
         )
         ed.to_zarr(overwrite=True)
-
         assert not any(
             isinstance(w.message, ZarrUserWarning)
             and "Consolidated metadata is currently not part in the Zarr format 3 specification"
@@ -870,3 +875,21 @@ def test_to_zarr_no_consolidated_metadata_warning(test_path):
             for w in caught_warnings
         )
 
+
+@pytest.mark.unit
+def test_to_zarr_no_deprecated_chunk_warning(test_path):
+    """
+    This test checks that dask rechunking receives dictionary and not tuple.
+    """
+    with warnings.catch_warnings(record=True) as caught_warnings:
+        warnings.simplefilter("always")
+        ed = open_raw(
+            test_path["EK60"] / "ncei-wcsd/SH1701/TEST-D20170114-T202932.raw",
+            sonar_model="EK60",
+        )
+        ed.to_zarr(overwrite=True)
+    assert not any(
+        isinstance(w.message, FutureWarning)
+        and "Supplying chunks as dimension-order tuples" in str(w.message)
+        for w in caught_warnings
+    )

--- a/echopype/tests/echodata/test_echodata.py
+++ b/echopype/tests/echodata/test_echodata.py
@@ -4,9 +4,10 @@ import os
 import fsspec
 from pathlib import Path
 import shutil
+import warnings
 
 from xarray import DataTree
-from zarr.errors import GroupNotFoundError
+from zarr.errors import GroupNotFoundError, ZarrUserWarning
 
 import echopype
 from echopype.echodata import EchoData
@@ -850,3 +851,23 @@ def test_echodata_delete(caplog, ek60_path):
 
     # Check that it doesn't exist
     assert not os.path.exists(temp_zarr_path)
+
+
+@pytest.mark.unit
+def test_to_zarr_no_consolidated_metadata_warning():
+    with warnings.catch_warnings(record=True) as caught_warnings:
+        warnings.simplefilter("always", ZarrUserWarning)
+        ed = open_raw(
+            "echopype/test_data/ek60/ncei-wcsd/"
+            "Summer2017-D20170719-T211347.raw",
+            sonar_model="EK60",
+        )
+        ed.to_zarr(overwrite=True)
+
+        assert not any(
+            isinstance(w.message, ZarrUserWarning)
+            and "Consolidated metadata is currently not part in the Zarr format 3 specification"
+            in str(w.message)
+            for w in caught_warnings
+        )
+

--- a/echopype/utils/coding.py
+++ b/echopype/utils/coding.py
@@ -3,6 +3,7 @@ from typing import Any, Dict, Tuple
 
 import numpy as np
 import xarray as xr
+from dask.array import Array as DaskArray
 from dask.array.core import auto_chunks
 from dask.utils import parse_bytes
 from xarray import coding
@@ -217,17 +218,21 @@ def set_zarr_encodings(
                 #    tolerance then no need to rechunk
                 if chunk_diff < chunk_size_tolerance:
                     rechunk = False
-                    chunks = existing_chunks
+                    dask_formatted_chunks = existing_chunks
 
             if rechunk:
                 # Use dask auto chunk to determine the optimal chunk
                 # spread for optimal chunk size
-                chunks = _get_dask_auto_chunk(val, chunk_size=chunk_size)
-                # Dask expects chunk dictionary but Zarr expects list-like iterable of
-                # values in encoding
-                chunks = [*chunks.values()]
+                dask_formatted_chunks = _get_dask_auto_chunk(val, chunk_size=chunk_size)
 
-            encoding[name]["chunks"] = chunks
+            # Dask expects chunk dictionary but Zarr expects list-like iterable of
+            # values in encoding
+            zarr_formatted_chunks = [*dask_formatted_chunks.values()]
+
+            encoding[name]["chunks"] = zarr_formatted_chunks
+            # Add temporary dask formatted_chunks to encoding for use in dask rechunking
+            if isinstance(ds[name].data, DaskArray):
+                encoding[name]["dask_formatted_chunks"] = dask_formatted_chunks
         if PREFERRED_CHUNKS in encoding[name]:
             # Remove 'preferred_chunks', use chunks only instead
             encoding[name].pop(PREFERRED_CHUNKS)

--- a/echopype/utils/io.py
+++ b/echopype/utils/io.py
@@ -76,7 +76,12 @@ def save_file(ds, path, mode, engine, group=None, compression_settings=None, **k
         for var, enc in encoding.items():
             if isinstance(ds[var].data, DaskArray):
                 ds[var] = ds[var].chunk(enc.get("chunks", {}))
-        ds.to_zarr(store=path.root, mode=mode, group=group, encoding=encoding, **kwargs)
+        # Set consolidated to False to avoid warning about consolidated metadata not being supported
+        # by Zarr 3
+        # TODO remove consolidated=False when Zarr 3 supports consolidated metadata
+        ds.to_zarr(
+            store=path.root, mode=mode, group=group, consolidated=False, encoding=encoding, **kwargs
+        )
     else:
         raise ValueError(f"{engine} is not a supported save format")
 

--- a/echopype/utils/io.py
+++ b/echopype/utils/io.py
@@ -72,8 +72,8 @@ def save_file(ds, path, mode, engine, group=None, compression_settings=None, **k
     if engine == "netcdf4":
         ds.to_netcdf(path=path, mode=mode, group=group, encoding=encoding, engine=engine, **kwargs)
     elif engine == "zarr":
-        # Dask chunk according to dask formatted chunk encoding. As the zarr chunks are inherited
-        # from the dask formatted chunks, we avoid any potential chunking mismatch between the two.
+        # Rechunk Dask array according to dask formatted chunk encoding. The zarr chunks are based
+        # on the dask formatted chunks, so we avoid any potential chunking mismatch between them.
         # If we do not do this, we will need to call `ds.to_zrar(...,align_chunks=True,...)`, which
         # also "rechunks the Dask array to align with Zarr chunks before writing"
         # (https://docs.xarray.dev/en/latest/generated/xarray.Dataset.to_zarr.html).

--- a/echopype/utils/io.py
+++ b/echopype/utils/io.py
@@ -72,10 +72,16 @@ def save_file(ds, path, mode, engine, group=None, compression_settings=None, **k
     if engine == "netcdf4":
         ds.to_netcdf(path=path, mode=mode, group=group, encoding=encoding, engine=engine, **kwargs)
     elif engine == "zarr":
-        # Ensure that encoding and chunks match
+        # Dask chunk according to dask formatted chunk encoding. As the zarr chunks are inherited
+        # from the dask formatted chunks, we avoid any potential chunking mismatch between the two.
+        # If we do not do this, we will need to call `ds.to_zrar(...,align_chunks=True,...)`, which
+        # also "rechunks the Dask array to align with Zarr chunks before writing"
+        # (https://docs.xarray.dev/en/latest/generated/xarray.Dataset.to_zarr.html).
         for var, enc in encoding.items():
             if isinstance(ds[var].data, DaskArray):
-                ds[var] = ds[var].chunk(enc.get("chunks", {}))
+                ds[var] = ds[var].chunk(enc.get("dask_formatted_chunks", {}))
+                # # Remove dask_formatted_chunks from encoding
+                encoding[var].pop("dask_formatted_chunks")
         # Set consolidated to False to avoid warning about consolidated metadata not being supported
         # by Zarr 3
         # TODO remove consolidated=False when Zarr 3 supports consolidated metadata


### PR DESCRIPTION
### Problem 1:

Dask needs dictionary chunk encoding and Zarr requires list-like chunk encoding.

I fix this by separating Dask and Zarr encodings and rechunking Dask with it's dictionary encoding and removing that encoding once the encoding dictionary is passed into `to_zarr`.

### Problem 2:

Xarray describes `to_zarr`'s `consolidated` parameter behavior as:

> If True, apply zarr’s consolidate_metadata function to the store after writing metadata and read existing stores with consolidated metadata; if False, do not. The default (consolidated=None) means write consolidated metadata and attempt to read consolidated metadata for existing stores (falling back to non-consolidated).

But Zarr v3 doesn't support consolidated metadata just yet, so we will always get this falling back to non-consolidated warning whenever we call `.to_zarr` on an Echodata object serialized using Zarr v3. Fixing this will handle one of the problems listed here: https://github.com/echostack-org/echopype-examples/issues/119.

I fix this by explicitly calling `consolidated=False`.