### PR TITLE
Add `qc` to `__init__.py`

### DIFF
--- a/echopype/__init__.py
+++ b/echopype/__init__.py
@@ -2,7 +2,7 @@ from __future__ import absolute_import, division, print_function
 
 from _echopype_version import version as __version__  # noqa
 
-from . import calibrate, clean, commongrid, consolidate, mask, utils
+from . import calibrate, clean, commongrid, consolidate, mask, qc, utils
 from .convert.api import open_raw
 from .echodata.api import open_converted
 from .echodata.combine import combine_echodata
@@ -24,6 +24,7 @@ __all__ = [
     "metrics",
     "open_converted",
     "open_raw",
+    "qc",
     "utils",
     "verbose",
 ]


### PR DESCRIPTION
Currently the `qc` subpackage is not adding to package level `__init__.py` so there's often import problems. This PR adds the subpackage (and we can debate whether these functions should live in `qc` or other places...).